### PR TITLE
The wiki can be seen by anonymous users.

### DIFF
--- a/Controller/WikiController.php
+++ b/Controller/WikiController.php
@@ -35,10 +35,9 @@ class WikiController extends Controller{
      *      name="icap_wiki_view"
      * )
      * @ParamConverter("wiki", class="IcapWikiBundle:Wiki", options={"id" = "wikiId"})
-     * @ParamConverter("user", options={"authenticatedUser" = true})
      * @Template()
      */
-    public function viewAction(Wiki $wiki, User $user)
+    public function viewAction(Wiki $wiki)
     {
         $this->checkAccess("OPEN", $wiki);
         $isAdmin = $this->isUserGranted("EDIT", $wiki);


### PR DESCRIPTION
It couldn't work if a user wasn't authenticated because this annotation will search for a user entity (from getToken()->getUser()).

Moreover the $user parameter was unused.
